### PR TITLE
fix: StopIteration error when channel number is not cast to an int

### DIFF
--- a/netaudio/console/commands/subscription/_add.py
+++ b/netaudio/console/commands/subscription/_add.py
@@ -60,7 +60,7 @@ class SubscriptionAddCommand(Command):
         elif self.option("tx-channel-number"):
             tx_channel = next(
                 filter(
-                    lambda c: c[1].number == self.option("tx-channel-number"),
+                    lambda c: c[1].number == int(self.option("tx-channel-number")),
                     tx_device.tx_channels.items(),
                 )
             )[1]
@@ -90,7 +90,7 @@ class SubscriptionAddCommand(Command):
         elif self.option("rx-channel-number"):
             rx_channel = next(
                 filter(
-                    lambda c: c[1].number == self.option("rx-channel-number"),
+                    lambda c: c[1].number == int(self.option("rx-channel-number")),
                     rx_device.rx_channels.items(),
                 )
             )[1]

--- a/netaudio/console/commands/subscription/_remove.py
+++ b/netaudio/console/commands/subscription/_remove.py
@@ -52,7 +52,7 @@ class SubscriptionRemoveCommand(Command):
         elif self.option("rx-channel-number"):
             rx_channel = next(
                 filter(
-                    lambda c: c[1].number == self.option("rx-channel-number"),
+                    lambda c: c[1].number == int(self.option("rx-channel-number")),
                     rx_device.rx_channels.items(),
                 )
             )[1]


### PR DESCRIPTION
Since channel number was not cast to an int, the channel was never matched and never found resulting in the following error even when using correct channel numbers for subscription add and remove commands.

```
  RuntimeError

  coroutine raised StopIteration

  at /usr/lib/python3.12/asyncio/base_events.py:687 in run_until_complete
       683│             future.remove_done_callback(_run_until_complete_cb)
       684│         if not future.done():
       685│             raise RuntimeError('Event loop stopped before Future completed.')
       686│ 
    →  687│         return future.result()
       688│ 
       689│     def stop(self):
       690│         
       691│ 
```

